### PR TITLE
Configure docker container network access

### DIFF
--- a/3.3.6/Dockerfile
+++ b/3.3.6/Dockerfile
@@ -1,14 +1,14 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.04
 
 
 ####################
 # JAVA
 ####################
 
-ENV JAVA_HOME		/usr/lib/jvm/java-8-openjdk-amd64
+ENV JAVA_HOME		/usr/lib/jvm/java-11-openjdk-amd64
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-8-jdk && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates openjdk-11-jdk && \
     rm -rf /var/lib/apt/lists/*
 
 
@@ -28,7 +28,7 @@ ENV YARN_NODEMANAGER_USER root
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y wget libzip4 libsnappy1v5 libssl-dev && \
-    wget http://archive.apache.org/dist/hadoop/core/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz && \
+    wget https://archive.apache.org/dist/hadoop/core/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz && \
     apt-get remove -y wget && \
     rm -rf /var/lib/apt/lists/* && \
     tar -zxf /hadoop-$HADOOP_VERSION.tar.gz && \


### PR DESCRIPTION
Update Dockerfile to use Ubuntu 24.04 and Java 11 to resolve `apt update` failures.

The `ubuntu:23.10` base image is End-of-Life, causing 404 errors when `apt update` attempts to reach its repositories. This update migrates to `ubuntu:24.04` (LTS) and adjusts Java to version 11, which is compatible with the new base image. It also adds `ca-certificates` and switches Hadoop download to HTTPS for improved security and reliability.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8aa07b3-eeee-4ccb-90f7-9fe518b3847a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8aa07b3-eeee-4ccb-90f7-9fe518b3847a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

